### PR TITLE
Make scaling more natural

### DIFF
--- a/qoiview.c
+++ b/qoiview.c
@@ -66,7 +66,7 @@ static void reset_image_params(void) {
 }
 
 static void scale(float d) {
-    state.image.scale += d;
+    state.image.scale *= expf(d);
     if (state.image.scale > MAX_SCALE) {
         state.image.scale = MAX_SCALE;
     }


### PR DESCRIPTION
status quo behavior feels very unnatural. When image is zoomed out it scales really fast but when it is zoomed in scaling is really slow. Now it's zooming with constant speed.